### PR TITLE
Do not apply sourcemap if option is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (options) {
     }
     file.contents = new Buffer(res.src);
 
-    if (file.sourceMap) {
+    if (opts.sourcemap && file.sourceMap) {
       applySourceMap(file, res.map);
     }
 


### PR DESCRIPTION
If the plugin is run with `{sourcemap: false}`, `applySourceMap()` should not be run as it will fail. Being able to not apply sourcemaps might be useful as following plugins might do this and fail because it has already been consumed.
