### PR TITLE
Fix source map file property

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,9 @@ module.exports = function (options) {
     file.contents = new Buffer(res.src);
 
     if (opts.sourcemap && file.sourceMap) {
-      var fileprop = file.sourceMap.file;
-      applySourceMap(file, res.map);
-      // Restore file property because source-map generator loose it for
-      // some reason. See
-      // <https://github.com/terinjokes/gulp-uglify/issues/53> for more
-      // details.
-      file.sourceMap.file = fileprop;
+      var sourceMap = JSON.parse(res.map);
+      sourceMap.file = file.relative.replace(/\\/g, '');
+      applySourceMap(file, sourceMap);
     }
 
     this.push(file);


### PR DESCRIPTION
The output source map was missing the `file` property because the source map generated by `ng-annotate` was missing it too. This adds the missing property.
