### PR TITLE
A fix for https://github.com/Kagami/gulp-ng-annotate/issues/9 for Windows - Replace \ with /

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (options) {
       var sourceMap = JSON.parse(res.map);
       // Workaround for GH-9.
       if (file.sourceMap.file !== file.relative) {
-        var relative = file.relative.replace("\\", "/");
+        var relative = file.relative.replace(/\\/g, "/");
         gutil.log("gulp-ng-annotate: workaround for GH-9: change sourcemap `file` option from `"+file.sourceMap.file+"` to `"+relative+"`; if that breaks your sourcemap setup, please comment at https://github.com/Kagami/gulp-ng-annotate/issues/9");
         file.sourceMap.file = relative;
       }


### PR DESCRIPTION
Related to #9 
