### PR TITLE
Upgrade merge version to patch vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/Kagami/gulp-ng-annotate",
   "dependencies": {
     "bufferstreams": "^1.1.0",
-    "merge": "^1.2.0",
+    "merge": "^1.2.1",
     "ng-annotate": "^1.2.1",
     "plugin-error": "^0.1.2",
     "through2": "^2.0.1",


### PR DESCRIPTION
The merge dependency had a vulnerability as documented in CVE-2018-16469. Version 1.2.1 fixed the issue.